### PR TITLE
New naming convention: alfna->exgam

### DIFF
--- a/XIAreader/source/userroutine/include/UserSort.h
+++ b/XIAreader/source/userroutine/include/UserSort.h
@@ -98,9 +98,9 @@ private:
 
 
     // Particle - gamma-ray coincidence matrix
-    Histogram2Dp alfna, alfna_bg;
-    Histogram2Dp alfna_ppac, alfna_ppac_bg;
-    Histogram2Dp alfna_veto_ppac, alfna_veto_ppac_bg;
+    Histogram2Dp exgam, exgam_bg;
+    Histogram2Dp exgam_ppac, exgam_ppac_bg;
+    Histogram2Dp exgam_veto_ppac, exgam_veto_ppac_bg;
 
     // Gain labr
     Parameter gain_labr;
@@ -142,7 +142,7 @@ private:
     Parameter thick_range;
 
 
-    // Time gates for the LaBr detectors, e.g. for making the ALFNA matrices
+    // Time gates for the LaBr detectors, e.g. for making the exgam matrices
     Parameter labr_time_cuts;
 
     // Time gates for the ppacs.

--- a/XIAreader/source/userroutine/src/UserSort.cpp
+++ b/XIAreader/source/userroutine/src/UserSort.cpp
@@ -350,23 +350,23 @@ void UserSort::CreateSpectra()
     sprintf(tmp2, "Excitation energy, all");
     h_ex_all = Spec(tmp, tmp2, 20000, 0, 20000, "Excitation energy [keV]");
 
-    sprintf(tmp, "alfna");
-    alfna = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
+    sprintf(tmp, "exgam");
+    exgam = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
 
-    sprintf(tmp, "alfna_bg");
-    alfna_bg = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
+    sprintf(tmp, "exgam_bg");
+    exgam_bg = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
 
-    sprintf(tmp, "alfna_ppac");
-    alfna_ppac = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
+    sprintf(tmp, "exgam_ppac");
+    exgam_ppac = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
 
-    sprintf(tmp, "alfna_ppac_bg");
-    alfna_ppac_bg = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
+    sprintf(tmp, "exgam_ppac_bg");
+    exgam_ppac_bg = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
 
-    sprintf(tmp, "alfna_veto_ppac");
-    alfna_veto_ppac = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
+    sprintf(tmp, "exgam_veto_ppac");
+    exgam_veto_ppac = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
 
-    sprintf(tmp, "alfna_veto_ppac_bg");
-    alfna_veto_ppac_bg = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
+    sprintf(tmp, "exgam_veto_ppac_bg");
+    exgam_veto_ppac_bg = Mat(tmp, tmp, 1500, 0, 15000, "LaBr [keV]", 1600, -1000, 15000, "Ex [keV]");
 
 
     n_fail_e = 0;
@@ -546,12 +546,12 @@ void UserSort::AnalyzeGamma(const word_t &de_word, const double &excitation,cons
             // Check time gate.
             switch ( CheckTimeStatus(tdiff, labr_time_cuts) ) {
                 case is_prompt : {
-                    alfna->Fill(energy, excitation);
+                    exgam->Fill(energy, excitation);
                     break;
                 }
                 case is_background : {
-                    alfna->Fill(energy, excitation, -1);
-                    alfna_bg->Fill(energy, excitation);
+                    exgam->Fill(energy, excitation, -1);
+                    exgam_bg->Fill(energy, excitation);
                     break;
                 }
                 case ignore : {
@@ -616,22 +616,22 @@ void UserSort::AnalyzeGammaPPAC(const word_t &de_word, const double &excitation,
             // Check time gate.
             switch ( CheckTimeStatus(tdiff, labr_time_cuts) ) {
                 case is_prompt : {
-                    alfna->Fill(energy, excitation);
+                    exgam->Fill(energy, excitation);
                     if (ppac_prompt)
-                        alfna_ppac->Fill(energy, excitation);
+                        exgam_ppac->Fill(energy, excitation);
                     else
-                        alfna_veto_ppac->Fill(energy, excitation);
+                        exgam_veto_ppac->Fill(energy, excitation);
                     break;
                 }
                 case is_background : {
-                    alfna->Fill(energy, excitation, -1);
-                    alfna_bg->Fill(energy, excitation);
+                    exgam->Fill(energy, excitation, -1);
+                    exgam_bg->Fill(energy, excitation);
                     if (ppac_prompt){
-                        alfna_ppac->Fill(energy, excitation, -1);
-                        alfna_ppac_bg->Fill(energy, excitation);
+                        exgam_ppac->Fill(energy, excitation, -1);
+                        exgam_ppac_bg->Fill(energy, excitation);
                     } else {
-                        alfna_veto_ppac->Fill(energy, excitation, -1);
-                        alfna_veto_ppac_bg->Fill(energy, excitation);
+                        exgam_veto_ppac->Fill(energy, excitation, -1);
+                        exgam_veto_ppac_bg->Fill(energy, excitation);
                     }
                     break;
                 }

--- a/input_files/RawSort.batch
+++ b/input_files/RawSort.batch
@@ -37,7 +37,7 @@ parameter ex_from_ede    = 14.5 -1.0436 -0.001220 \
 14.5 -1.0177 -0.001220 \
 
 
-# labbr time gates, for making the ALFNA matrices 
+# labbr time gates, for making the exgam matrices 
 # found by looking at the m_nai_t plot and projecting it
 # down to the x-axis/m_nai_e_t_c x-axis plot 
 # remember to subtract the same amount of channels 


### PR DESCRIPTION
New Speak: In order to make us better understood, we abolish the historical name "alfna" in favor for a new name that describes the axis: Ex vs Egamma (exgam)